### PR TITLE
Cd fix

### DIFF
--- a/src/cd_util/test.s
+++ b/src/cd_util/test.s
@@ -13,6 +13,7 @@
 
 ; --- CD Entry Point ---
 start_cd:
+;summer_break:
     LDA #<PATH_INPUT
     STA PATH_PTR_LO             ; zero-page low byte of path pointer
     LDA #>PATH_INPUT
@@ -31,7 +32,7 @@ start_cd:
 
 absolute_path_cd:
     ; Absolute path - start from root
-    LDA #0
+    LDA #1
     STA CURRENT_INODE           ; Start from root inode 0
 
 resolve_path_cd:

--- a/src/lcd_driver/test.s
+++ b/src/lcd_driver/test.s
@@ -193,7 +193,7 @@
 ;HOW TO CREATE THE PR
 ; git checkout -b 'empty_cmd_fix'
 ; git commit -am 'fixed the code so that when an empty cmd was inserted, Unknown cmd was not printed'
-; git push origin master
+; git push --set-upstream origin empty_cmd_fix
 ; 
 ;
 ;

--- a/src/lcd_driver/test.s
+++ b/src/lcd_driver/test.s
@@ -155,6 +155,23 @@
 
 ; see lcd_backspace:
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;commit 278353e824d5040f82e7740db04c2ac4c2ec76bc
+;added LDA #0
+;STA KEY_INPUT
+ 
+;The code would previously continuously print "unknown command" nonstop before, 
+;when it was supposed to only print it once.
+;This bug would happen because the code would see KEY_INPUT 
+;and print unknown command depending on if there were any pending strings inside of
+;KEY_INPUT. But inside of the reset shell (part of the code where the shell
+;prepares for the next command), there was no form of
+;reseting KEY_INPUT after it was printed onto the LCD, resulting
+;in the computer thinking it has still not been printed onto the LCD.
+;The computer would then attempt to print KEY_INPUT onto the LCD over and over.
+;
+;The fix added, puts a value of 0 into the KEY_INPUT, reseting the pending strings inside KEY_INPUT.
+;
 
 start_lcd:
     ; *** CLEAR KEY BUFFER HERE! ***
@@ -236,6 +253,10 @@ handle_enter:
 reset_shell:
     LDX #0
     STX CMD_INDEX
+    ;Reset KEY_INPUT
+    LDA #0
+    STA KEY_INPUT
+
     ; Move to next line in unified buffer
     JSR lcd_new_line
     JSR print_prompt

--- a/src/lcd_driver/test.s
+++ b/src/lcd_driver/test.s
@@ -198,12 +198,21 @@
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;commit afdf0d090aecc4452bbaf2c61ce5975bd864afd2 
-;Fixed cd errors (like cd .. and cd rom not working)
+;Fixed cd errors, like when inserting cd.. while in or trying to access the root directory,
+;cd fail appearing.
 ;
 ;Shifted all inode numbers up by one so that inode 0 is never used.
 ;Inode 0 is reserved to show an invalid inode, so inode 0 should not be assigned to the root directory.
 ;The fix was to move the root to inode 1, and update the code so that any command 
 ;referring back to the root now loads inode 1 instead of 0.
+;
+;Tested by inserting cd.. while in and trying to access the root directory.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;Testing:
+;Tested backspace by deleting m from cd rom
+;Tested cd by changing directory from root to rin
+;Tested cd ..  by changing from rom to root directory
+;Tested enter by pressing enter while in a empty cmd
 ;
 ;
 ;

--- a/src/lcd_driver/test.s
+++ b/src/lcd_driver/test.s
@@ -172,6 +172,34 @@
 ;
 ;The fix added, puts a value of 0 into the KEY_INPUT, reseting the pending strings inside KEY_INPUT.
 ;
+;commit 433554cde7c1da66c501cb3800e75ea1f86ffb24
+;Added 
+;LDA CMD_INDEX
+;BEQ reset_shell
+;
+;
+;The code would previously still print Unknown cmd even if
+;there was no cmd inserted into the lcd.
+;
+;This bug could be fixed by adding LDA CMD_INDEX and BEQ reset_shell
+;into handle_enter so that the code could branch to reset_shell as long as CMD_INDEX had
+;the value of "0" (Since CMD_INDEX keeps track of how many characters was typed, if CMD_INDEX
+;has a value of 0, basically nothing or enter was typed into the LCD) (BEQ also branches if the
+;last operation loaded was a 0. (Only LDA works like this as STA does not work as the registor values do not change))
+;
+;Now the LCD prints the prompt again "<" when nothing/enter was typed into the LCD. 
+;
+;
+;HOW TO CREATE THE PR
+; git checkout -b 'empty_cmd_fix'
+; git commit -am 'fixed the code so that when an empty cmd was inserted, Unknown cmd was not printed'
+; git push origin master
+; 
+;
+;
+;
+;
+;
 
 start_lcd:
     ; *** CLEAR KEY BUFFER HERE! ***
@@ -248,6 +276,8 @@ handle_backspace:
     JMP keyinput_loop
 
 handle_enter:
+    LDA CMD_INDEX
+    BEQ reset_shell
     JSR process_shell_cmd
 
 reset_shell:
@@ -702,4 +732,4 @@ done_unk:
 ; === Data ===
 
 prompt_msg:     .byte "> ", 0
-unk_msg:        .byte "Unknown command", 0
+unk_msg:        .byte " UK_CMD", 0

--- a/src/lcd_driver/test.s
+++ b/src/lcd_driver/test.s
@@ -196,7 +196,14 @@
 ; git push --set-upstream origin empty_cmd_fix
 ; 
 ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;commit afdf0d090aecc4452bbaf2c61ce5975bd864afd2 
+;Fixed cd errors (like cd .. and cd rom not working)
 ;
+;Shifted all inode numbers up by one so that inode 0 is never used.
+;Inode 0 is reserved to show an invalid inode, so inode 0 should not be assigned to the root directory.
+;The fix was to move the root to inode 1, and update the code so that any command 
+;referring back to the root now loads inode 1 instead of 0.
 ;
 ;
 ;
@@ -210,7 +217,7 @@ start_lcd:
     JSR print_prompt
 
 init_working_dir:
-     LDA #0                      ; Start at root directory
+     LDA #1                      ; Start at root directory
      STA WORKING_DIR_INODE
 
 keyinput_loop:

--- a/src/ls_util/test.s
+++ b/src/ls_util/test.s
@@ -49,7 +49,7 @@ start_ls:
 
 absolute_path:
     ; Absolute path - start from root ; pwd support
-    LDA #0
+    LDA #1
     STA CURRENT_INODE           ; Start from root inode 0
     JMP resolve_path
 

--- a/src/rom_fs/test.s
+++ b/src/rom_fs/test.s
@@ -14,106 +14,118 @@ InitBaseAddresses:
 SetBitmaps:
     LDA #%01111111         ; Blocks 0-4 + 6 used
     STA BLOCK_BITMAP       ; Block bitmap
-    LDA #%00111111         ; Inodes 0-5 used
+    LDA #%01111111         ; Inodes 1-6 used (0 reserved for invalid) ;root directory inode fix
     STA INODE_BITMAP       ; Inode bitmap
 
-; === Inode 0: root directory ===
+; === Inode 0: reserved for invalid inodes ===  ;root directory inode fix
+    LDA #$00               ;root directory inode fix
+    STA INODE_BASE+$00     ;root directory inode fix
+    STA INODE_BASE+$01     ;root directory inode fix
+    STA INODE_BASE+$02     ;root directory inode fix
+    STA INODE_BASE+$03     ;root directory inode fix
+    STA INODE_BASE+$04     ;root directory inode fix
+    STA INODE_BASE+$05     ;root directory inode fix
+    STA INODE_BASE+$06     ;root directory inode fix
+    STA INODE_BASE+$07     ;root directory inode fix
+    STA INODE_BASE+$08     ;root directory inode fix
+
+; === Inode 1: root directory ===  ;root directory inode fix
     LDA #%00010001
-    STA INODE_BASE+$00     ; i_mode
+    STA INODE_BASE+$10     ; i_mode ;root directory inode fix
     LDA #$00
-    STA INODE_BASE+$01     ; uid
+    STA INODE_BASE+$11     ; uid ;root directory inode fix
     LDA #$50               ; size = 5 entries * 16 (added . and ..) ; dot, dot_dot entries
-    STA INODE_BASE+$02     ; 
+    STA INODE_BASE+$12     ; ;root directory inode fix
     LDA #$00
-    STA INODE_BASE+$03
-    STA INODE_BASE+$04
-    STA INODE_BASE+$05
+    STA INODE_BASE+$13     ;root directory inode fix
+    STA INODE_BASE+$14     ;root directory inode fix
+    STA INODE_BASE+$15     ;root directory inode fix
     LDA #$00
-    STA INODE_BASE+$06     ; block 0
+    STA INODE_BASE+$16     ; block 0 ;root directory inode fix
     LDA #INVALID_DATABLOCK
-    STA INODE_BASE+$07
-    STA INODE_BASE+$08
+    STA INODE_BASE+$17     ;root directory inode fix
+    STA INODE_BASE+$18     ;root directory inode fix
 
-; === Inode 1: README.txt ===
+; === Inode 2: README.txt ===  ;root directory inode fix
     LDA #%00000001
-    STA INODE_BASE+$10
-    STA INODE_BASE+$11
+    STA INODE_BASE+$20     ;root directory inode fix
+    STA INODE_BASE+$21     ;root directory inode fix
     LDA #$00
-    STA INODE_BASE+$12
+    STA INODE_BASE+$22     ;root directory inode fix
     LDA #$04
-    STA INODE_BASE+$13     ; size = 1024 bytes
-    STA INODE_BASE+$14
-    STA INODE_BASE+$15
+    STA INODE_BASE+$23     ; size = 1024 bytes ;root directory inode fix
+    STA INODE_BASE+$24     ;root directory inode fix
+    STA INODE_BASE+$25     ;root directory inode fix
     LDA #$01
-    STA INODE_BASE+$16     ; i_block[0] = block 1
+    STA INODE_BASE+$26     ; i_block[0] = block 1 ;root directory inode fix
     LDA #$02
-    STA INODE_BASE+$17     ; i_block[1] = block 2
+    STA INODE_BASE+$27     ; i_block[1] = block 2 ;root directory inode fix
     LDA #$07
-    STA INODE_BASE+$18     ; i_block[2] = block 6 (indirect)
+    STA INODE_BASE+$28     ; i_block[2] = block 6 (indirect) ;root directory inode fix
 
-; === Inode 2: /ram ===
+; === Inode 3: /ram ===  ;root directory inode fix
     LDA #%00010001
-    STA INODE_BASE+$20
-    STA INODE_BASE+$21
+    STA INODE_BASE+$30     ;root directory inode fix
+    STA INODE_BASE+$31     ;root directory inode fix
     LDA #$20               ; size = 2 entries * 16 (. and ..) ; dot, dot_dot entries
-    STA INODE_BASE+$22     ; dot, dot_dot entries
-    STA INODE_BASE+$23
-    STA INODE_BASE+$24
-    STA INODE_BASE+$25
+    STA INODE_BASE+$32     ; dot, dot_dot entries ;root directory inode fix
+    STA INODE_BASE+$33     ;root directory inode fix
+    STA INODE_BASE+$34     ;root directory inode fix
+    STA INODE_BASE+$35     ;root directory inode fix
     LDA #$05
-    STA INODE_BASE+$26     ; block 5
+    STA INODE_BASE+$36     ; block 5 ;root directory inode fix
     LDA #INVALID_DATABLOCK
-    STA INODE_BASE+$27
-    STA INODE_BASE+$28
+    STA INODE_BASE+$37     ;root directory inode fix
+    STA INODE_BASE+$38     ;root directory inode fix
 
-; === Inode 3: /rom ===
+; === Inode 4: /rom ===  ;root directory inode fix
     LDA #%00010001
-    STA INODE_BASE+$30
-    STA INODE_BASE+$31
+    STA INODE_BASE+$40     ;root directory inode fix
+    STA INODE_BASE+$41     ;root directory inode fix
     LDA #$40               ; size = 4 entries * 16 (., .., romfs.txt, bin) ; dot, dot_dot entries
-    STA INODE_BASE+$32     ; dot, dot_dot entries
-    STA INODE_BASE+$33
-    STA INODE_BASE+$34
-    STA INODE_BASE+$35
+    STA INODE_BASE+$42     ; dot, dot_dot entries ;root directory inode fix
+    STA INODE_BASE+$43     ;root directory inode fix
+    STA INODE_BASE+$44     ;root directory inode fix
+    STA INODE_BASE+$45     ;root directory inode fix
     LDA #$06
-    STA INODE_BASE+$36     ; block 6
+    STA INODE_BASE+$46     ; block 6 ;root directory inode fix
     LDA #INVALID_DATABLOCK
-    STA INODE_BASE+$37
-    STA INODE_BASE+$38
+    STA INODE_BASE+$47     ;root directory inode fix
+    STA INODE_BASE+$48     ;root directory inode fix
 
-; === Inode 4: romFS.txt ===
+; === Inode 5: romFS.txt ===  ;root directory inode fix
     LDA #%00000001
-    STA INODE_BASE+$40
-    STA INODE_BASE+$41
-    STA INODE_BASE+$42
-    STA INODE_BASE+$43
-    STA INODE_BASE+$44
-    STA INODE_BASE+$45
+    STA INODE_BASE+$50     ;root directory inode fix
+    STA INODE_BASE+$51     ;root directory inode fix
+    STA INODE_BASE+$52     ;root directory inode fix
+    STA INODE_BASE+$53     ;root directory inode fix
+    STA INODE_BASE+$54     ;root directory inode fix
+    STA INODE_BASE+$55     ;root directory inode fix
     LDA #$08
-    STA INODE_BASE+$46
+    STA INODE_BASE+$56     ;root directory inode fix
     LDA #INVALID_DATABLOCK
-    STA INODE_BASE+$47
-    STA INODE_BASE+$48
+    STA INODE_BASE+$57     ;root directory inode fix
+    STA INODE_BASE+$58     ;root directory inode fix
 
-; === Inode 5: /rom/bin ===
+; === Inode 6: /rom/bin ===  ;root directory inode fix
     LDA #%00010001
-    STA INODE_BASE+$50
-    STA INODE_BASE+$51
+    STA INODE_BASE+$60     ;root directory inode fix
+    STA INODE_BASE+$61     ;root directory inode fix
     LDA #$20               ; size = 2 entries * 16 (. and ..) ; dot, dot_dot entries
-    STA INODE_BASE+$52     ; dot, dot_dot entries
-    STA INODE_BASE+$53
-    STA INODE_BASE+$54
-    STA INODE_BASE+$55
+    STA INODE_BASE+$62     ; dot, dot_dot entries ;root directory inode fix
+    STA INODE_BASE+$63     ;root directory inode fix
+    STA INODE_BASE+$64     ;root directory inode fix
+    STA INODE_BASE+$65     ;root directory inode fix
     LDA #$09
-    STA INODE_BASE+$56     ; reused block 4 (for testing, update if needed)
+    STA INODE_BASE+$66     ; reused block 4 (for testing, update if needed) ;root directory inode fix
     LDA #INVALID_DATABLOCK
-    STA INODE_BASE+$57
-    STA INODE_BASE+$58
+    STA INODE_BASE+$67     ;root directory inode fix
+    STA INODE_BASE+$68     ;root directory inode fix
 
 ; === Root dir @ block 0 ===
-    ; Entry 1: . (current directory - points to inode 0) ; dot, dot_dot entries
-    LDA #$00               ; dot, dot_dot entries
-    STA BLOCK_BASE+$000    ; dot, dot_dot entries
+    ; Entry 1: . (current directory - points to inode 1) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$01               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$000    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$001    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -125,8 +137,8 @@ Loop_DOT:                  ; dot, dot_dot entries
     BNE Loop_DOT           ; dot, dot_dot entries
 
     ; Entry 2: .. (parent directory - root has no parent, points to itself) ; dot, dot_dot entries
-    LDA #$00               ; dot, dot_dot entries
-    STA BLOCK_BASE+$010    ; dot, dot_dot entries
+    LDA #$01               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$010    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$011    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -138,8 +150,8 @@ Loop_DOTDOT:               ; dot, dot_dot entries
     BNE Loop_DOTDOT        ; dot, dot_dot entries
 
     ; Entry 3: README.txt ; dot, dot_dot entries
-    LDA #$01
-    STA BLOCK_BASE+$020    ; dot, dot_dot entries
+    LDA #$02               ;root directory inode fix
+    STA BLOCK_BASE+$020    ; dot, dot_dot entries ;root directory inode fix
     LDA #$00
     STA BLOCK_BASE+$021    ; dot, dot_dot entries
     LDX #$00
@@ -151,8 +163,8 @@ Loop_README:
     BNE Loop_README
 
     ; Entry 4: ram ; dot, dot_dot entries
-    LDA #$02
-    STA BLOCK_BASE+$030    ; dot, dot_dot entries
+    LDA #$03               ;root directory inode fix
+    STA BLOCK_BASE+$030    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01
     STA BLOCK_BASE+$031    ; dot, dot_dot entries
     LDX #$00
@@ -164,8 +176,8 @@ Loop_RAM:
     BNE Loop_RAM
 
     ; Entry 5: rom ; dot, dot_dot entries
-    LDA #$03
-    STA BLOCK_BASE+$040    ; dot, dot_dot entries
+    LDA #$04               ;root directory inode fix
+    STA BLOCK_BASE+$040    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01
     STA BLOCK_BASE+$041    ; dot, dot_dot entries
     LDX #$00
@@ -177,9 +189,9 @@ Loop_ROM:
     BNE Loop_ROM
 
 ; === /ram dir @ block 5 === ; dot, dot_dot entries
-    ; Entry 1: . (current directory - points to inode 2) ; dot, dot_dot entries
-    LDA #$02               ; dot, dot_dot entries
-    STA BLOCK_BASE+$500    ; dot, dot_dot entries
+    ; Entry 1: . (current directory - points to inode 3) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$03               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$500    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$501    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -190,9 +202,9 @@ Loop_RAM_DOT:              ; dot, dot_dot entries
     CPX #14                ; dot, dot_dot entries
     BNE Loop_RAM_DOT       ; dot, dot_dot entries
 
-    ; Entry 2: .. (parent directory - points to root inode 0) ; dot, dot_dot entries
-    LDA #$00               ; dot, dot_dot entries
-    STA BLOCK_BASE+$510    ; dot, dot_dot entries
+    ; Entry 2: .. (parent directory - points to root inode 1) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$01               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$510    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$511    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -204,9 +216,9 @@ Loop_RAM_DOTDOT:           ; dot, dot_dot entries
     BNE Loop_RAM_DOTDOT    ; dot, dot_dot entries
 
 ; === /rom dir @ block 6 ===
-    ; Entry 1: . (current directory - points to inode 3) ; dot, dot_dot entries
-    LDA #$03               ; dot, dot_dot entries
-    STA BLOCK_BASE+$600    ; dot, dot_dot entries
+    ; Entry 1: . (current directory - points to inode 4) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$04               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$600    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$601    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -217,9 +229,9 @@ Loop_ROM_DOT:              ; dot, dot_dot entries
     CPX #14                ; dot, dot_dot entries
     BNE Loop_ROM_DOT       ; dot, dot_dot entries
 
-    ; Entry 2: .. (parent directory - points to root inode 0) ; dot, dot_dot entries
-    LDA #$00               ; dot, dot_dot entries
-    STA BLOCK_BASE+$610    ; dot, dot_dot entries
+    ; Entry 2: .. (parent directory - points to root inode 1) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$01               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$610    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$611    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -231,8 +243,8 @@ Loop_ROM_DOTDOT:           ; dot, dot_dot entries
     BNE Loop_ROM_DOTDOT    ; dot, dot_dot entries
 
     ; Entry 3: romFS.txt ; dot, dot_dot entries
-    LDA #$04
-    STA BLOCK_BASE+$620    ; dot, dot_dot entries
+    LDA #$05               ;root directory inode fix
+    STA BLOCK_BASE+$620    ; dot, dot_dot entries ;root directory inode fix
     LDA #$00
     STA BLOCK_BASE+$621    ; dot, dot_dot entries
     LDX #$00
@@ -244,8 +256,8 @@ Loop_romFS:
     BNE Loop_romFS
 
     ; Entry 4: bin ; dot, dot_dot entries
-    LDA #$05
-    STA BLOCK_BASE+$630    ; dot, dot_dot entries
+    LDA #$06               ;root directory inode fix
+    STA BLOCK_BASE+$630    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01
     STA BLOCK_BASE+$631    ; dot, dot_dot entries
     LDX #$00
@@ -257,9 +269,9 @@ Loop_bin:
     BNE Loop_bin
 
 ; === /rom/bin dir @ block 9 === ; dot, dot_dot entries
-    ; Entry 1: . (current directory - points to inode 5) ; dot, dot_dot entries
-    LDA #$05               ; dot, dot_dot entries
-    STA BLOCK_BASE+$900    ; dot, dot_dot entries
+    ; Entry 1: . (current directory - points to inode 6) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$06               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$900    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$901    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -270,9 +282,9 @@ Loop_BIN_DOT:              ; dot, dot_dot entries
     CPX #14                ; dot, dot_dot entries
     BNE Loop_BIN_DOT       ; dot, dot_dot entries
 
-    ; Entry 2: .. (parent directory - points to /rom inode 3) ; dot, dot_dot entries
-    LDA #$03               ; dot, dot_dot entries
-    STA BLOCK_BASE+$910    ; dot, dot_dot entries
+    ; Entry 2: .. (parent directory - points to /rom inode 4) ; dot, dot_dot entries ;root directory inode fix
+    LDA #$04               ; dot, dot_dot entries ;root directory inode fix
+    STA BLOCK_BASE+$910    ; dot, dot_dot entries ;root directory inode fix
     LDA #$01               ; dot, dot_dot entries
     STA BLOCK_BASE+$911    ; dot, dot_dot entries
     LDX #$00               ; dot, dot_dot entries
@@ -348,18 +360,18 @@ ROM_name:     .byte "rom", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ROMFS_name:   .byte "romfs.txt", 0, 0, 0, 0
 BIN_name:     .byte "bin", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
-; Updated directory structure:
-; .
-; ├── . (inode 0)
-; ├── .. (inode 0)
-; ├── Readme.txt (inode 1)
-; ├── /ram (inode 2)
-; │   ├── . (inode 2)
-; │   └── .. (inode 0)
-; └── /rom (inode 3)
-;     ├── . (inode 3)
-;     ├── .. (inode 0)
-;     ├── romFS.txt (inode 4)
-;     └── /bin (inode 5)
-;         ├── . (inode 5)
-;         └── .. (inode 3)
+; Updated directory structure: ;root directory inode fix
+; . ;root directory inode fix
+; ├── . (inode 1) ;root directory inode fix
+; ├── .. (inode 1) ;root directory inode fix
+; ├── Readme.txt (inode 2) ;root directory inode fix
+; ├── /ram (inode 3) ;root directory inode fix
+; │   ├── . (inode 3) ;root directory inode fix
+; │   └── .. (inode 1) ;root directory inode fix
+; └── /rom (inode 4) ;root directory inode fix
+;     ├── . (inode 4) ;root directory inode fix
+;     ├── .. (inode 1) ;root directory inode fix
+;     ├── romFS.txt (inode 5) ;root directory inode fix
+;     └── /bin (inode 6) ;root directory inode fix
+;         ├── . (inode 6) ;root directory inode fix
+;         └── .. (inode 4) ;root directory inode fix


### PR DESCRIPTION
;commit afdf0d090aecc4452bbaf2c61ce5975bd864afd2 
;Fixed cd errors, like when inserting cd.. while in or trying to access the root directory,
;cd fail appearing.
;
;Shifted all inode numbers up by one so that inode 0 is never used.
;Inode 0 is reserved to show an invalid inode, so inode 0 should not be assigned to the root directory.
;The fix was to move the root to inode 1, and update the code so that any command 
;referring back to the root now loads inode 1 instead of 0.
;
;Tested by inserting cd.. while in and trying to access the root directory.
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
;Testing:
;Tested backspace by deleting m from cd rom
;Tested cd by changing directory from root to rin
;Tested cd ..  by changing from rom to root directory
;Tested enter by pressing enter while in a empty cmd